### PR TITLE
Fix bug edit command can produce same person

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -82,7 +82,7 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        if (!personToEdit.isSamePerson(editedPerson) || model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 


### PR DESCRIPTION
Duplicate Contact can exist in the contact list with the use of the edit command. Fixes #199

Add command now only support multiple prefixes for "tags".
Edit command now will check if edited information of a person is the same as before edited and edited information of a person is already in the list.